### PR TITLE
1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Release](https://jitpack.io/v/stanwood/Analytics_Framework_android.svg?style=flat-square)](https://jitpack.io/#stanwood/Analytics_Framework_android)
+[![API](https://img.shields.io/badge/API-16%2B-blue.svg?style=flat)](https://android-arsenal.com/api?level=16)
 
 # Analytics Framework (Android)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
+//apply plugin: 'io.fabric'
 apply plugin: 'com.google.firebase.firebase-perf'
 
 android {
@@ -27,8 +27,8 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'io.fabric.tools:gradle:1.25.4'
+        classpath 'com.android.tools.build:gradle:3.2.0-beta05'
+        //classpath 'io.fabric.tools:gradle:1.25.4'
         classpath 'com.google.firebase:firebase-plugins:1.1.5'
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,4 +49,8 @@ dependencies {
     releaseImplementation project(':adjusttrackingprovider')
     implementation "com.android.support:appcompat-v7:$rootProject.ext.SupportLibVersion"
     implementation "com.google.firebase:firebase-perf:$rootProject.ext.FirebasePerfVersion"
+
+    implementation("com.google.firebase:firebase-analytics:16.0.3")
+    implementation("com.google.firebase:firebase-analytics-impl:16.2.1")
+    implementation("com.google.android.gms:play-services-measurement-base:16.0.2")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,10 +22,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-        <meta-data
+        <!--<meta-data
             android:name="io.fabric.ApiKey"
             android:value=""
-            />
+            />-->
     </application>
 
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ allprojects {
         TargetSdkVersion = 27
         CompileSdkVersion = 27
         SupportLibVersion = '27.0.2'
-        FirebasePerfVersion = '11.8.0'
         FirebaseCoreVersion = '16.0.1'
         FirebaseCrashVersion = '16.0.1'
         FirebasePerfVersion = '16.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,10 @@ allprojects {
         TargetSdkVersion = 27
         CompileSdkVersion = 27
         SupportLibVersion = '27.1.1'
-        FirebasePerfVersion = '11.8.0'
-        FirebaseCoreVersion = '16.0.1'
-        FirebaseCrashVersion = '16.0.1'
-        FirebasePerfVersion = '16.0.0'
-        PlayServicesAnalyticsVersion = '16.0.1'
+        FirebaseCoreVersion = '16.0.3'
+        FirebaseCrashVersion = '16.2.0'
+        FirebasePerfVersion = '16.1.0'
+        PlayServicesAnalyticsVersion = '16.0.3'
         FrameworkVersion = '1.1.12'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.0-beta05'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }
@@ -19,10 +19,11 @@ allprojects {
     }
 
     project.ext {
-        MinSdkVersion = 21
+        MinSdkVersion = 16
         TargetSdkVersion = 27
         CompileSdkVersion = 27
-        SupportLibVersion = '27.0.2'
+        SupportLibVersion = '27.1.1'
+        FirebasePerfVersion = '11.8.0'
         FirebaseCoreVersion = '16.0.1'
         FirebaseCrashVersion = '16.0.1'
         FirebasePerfVersion = '16.0.0'

--- a/fabrictrackingprovider/build.gradle
+++ b/fabrictrackingprovider/build.gradle
@@ -21,7 +21,7 @@ repositories {
 dependencies {
     implementation project(':core')
     implementation "com.android.support:support-annotations:$rootProject.ext.SupportLibVersion"
-    api 'com.crashlytics.sdk.android:crashlytics:2.9.2'
+    api 'com.crashlytics.sdk.android:crashlytics:2.9.4'
     api project(':fabrictrackingprovider-shared')
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 02 16:46:07 CEST 2018
+#Mon Aug 06 19:19:05 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/stanwoodanalytics/src/main/java/io/stanwood/framework/analytics/DefaultOptOutDialogFactory.java
+++ b/stanwoodanalytics/src/main/java/io/stanwood/framework/analytics/DefaultOptOutDialogFactory.java
@@ -1,0 +1,12 @@
+package io.stanwood.framework.analytics;
+
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+
+public class DefaultOptOutDialogFactory implements OptOutDialogFactory {
+    @NonNull
+    @Override
+    public DialogFragment createDialog() {
+        return new OptOutDialog();
+    }
+}

--- a/stanwoodanalytics/src/main/java/io/stanwood/framework/analytics/OptOutDialogFactory.java
+++ b/stanwoodanalytics/src/main/java/io/stanwood/framework/analytics/OptOutDialogFactory.java
@@ -1,0 +1,9 @@
+package io.stanwood.framework.analytics;
+
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+
+public interface OptOutDialogFactory {
+    @NonNull
+    DialogFragment createDialog();
+}

--- a/stanwoodanalytics/src/main/java/io/stanwood/framework/analytics/TrackerTree.java
+++ b/stanwoodanalytics/src/main/java/io/stanwood/framework/analytics/TrackerTree.java
@@ -7,7 +7,7 @@ import android.util.Log;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 
 import io.stanwood.framework.analytics.generic.TrackerContainer;
 import io.stanwood.framework.analytics.generic.TrackerParams;
@@ -44,9 +44,15 @@ class TrackerTree extends Timber.Tree {
 
     private String getMessage(Throwable throwable) {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        try (PrintStream printStream = new PrintStream(out)) {
+        PrintStream printStream = null;
+        try {
+            printStream = new PrintStream(out);
             throwable.printStackTrace(printStream);
-            return new String(out.toByteArray(), StandardCharsets.UTF_8);
+            return new String(out.toByteArray(), Charset.forName("UTF-8"));
+        } finally {
+            if (printStream != null) {
+                printStream.close();
+            }
         }
     }
 }


### PR DESCRIPTION
*This release contains a few Firebase dependency and support library updates and thus might be incompatible with your app!*

- Lower minSdk to 16
- Update Firebase and support library dependencies
- Close print stream after usage in Timber tracker tree
- Allow passing a custom tracking opt-out dialog to your `BaseAnalyticsTracker` implementation